### PR TITLE
Adding weekly tpr and vaccination coverage to final data

### DIFF
--- a/report_sources/assemble_data.Rmd
+++ b/report_sources/assemble_data.Rmd
@@ -726,11 +726,11 @@ path_export <- here::here("data",
                           file_name)
 dir_export <- dirname(path_export)
 if (!dir.exists(dir_export)) dir.create(dir_export)
-rio::export(final_dat, path_export)
+rio::export(elr_extras_final, path_export)
 
 
 ## export data to rds file in current folder
-rio::export(final_dat, file_name)
+rio::export(elr_extras_final, file_name)
 
 
 ```

--- a/report_sources/assemble_data.Rmd
+++ b/report_sources/assemble_data.Rmd
@@ -110,6 +110,8 @@ phi <- all_dat$phi_data
 ```
 
 
+
+
 ## Country list
 
 ```{r}
@@ -470,6 +472,8 @@ final_dat <- final_dat %>%
 
 
 
+
+
 ## Add rolling 7-day case/death rates per 100k
 
 ```{r}
@@ -627,3 +631,106 @@ rio::export(final_dat, file_name)
 
 ```
 
+
+# Save additional dataset for ELR review
+
+
+## Adding Vaccination coverage  
+
+Columns added include:  
+
+* Number of vaccine doses administered (total numbers and per 100 people)
+* Persons receiving at least 1 dose of vaccine (total numbers and per 100 people)
+* Persons fully vaccinated (total numbers and per 100 people) 
+
+
+```{r}
+# pull in vaccine data from OWID
+vax_data <- phifunc::pull_owid_vax()
+
+vax_data <- vax_data %>%
+  group_by(iso3) %>%
+  filter(!is.na(total_vaccinations),
+         date == max(date)) %>% 
+  select(
+    iso3,
+    population,
+    as_of_vaccine = date,
+    vaccinations = total_vaccinations,
+    vac_oneplus_dose = people_vaccinated,
+    vac_full = people_fully_vaccinated,
+  ) %>%
+  mutate(
+    across(
+      starts_with("vac"),
+      list("per_100" = ~ . / population * 100) 
+    )
+  ) %>% 
+  select(-population) %>% 
+  ungroup()
+ 
+```
+
+## Adding weekly testing data
+
+Columns added include:  
+
+* Weekly (by ISO week tests, cases, and percent positivity with CIs)
+* The same measures, for one week prior
+
+```{r}
+# pull in vaccine data from OWID
+testing_data_final <- all_dat$testing_data2 %>% 
+  filter(!(last_updated < week_end_date)) %>% 
+  select(iso3,
+         week_end_date,
+         test_denom = tests,
+         test_num = cases) %>% 
+  group_by(iso3) %>% 
+  arrange(desc(week_end_date)) %>% 
+  slice(1:2) %>% 
+  mutate(time_frame = 1:n()) %>% 
+  ungroup() %>% 
+  pivot_wider(
+    names_from = time_frame, 
+    values_from = c(week_end_date, test_denom, test_num), 
+    names_glue = "{.value}_{case_when(time_frame == 1 ~ 'recent', time_frame == 2 ~ 'before')}"
+  ) %>% 
+  rename_with(
+    ~gsub("week_end_date", "tpr_last_date", .x)
+  ) %>% 
+  mutate(
+    tpr_recent = test_num_recent / test_denom_recent,
+    tpr_lower_recent = prop_ci(test_num_recent, test_denom_recent, result = "lower"),
+    tpr_upper_recent = prop_ci(test_num_recent, test_denom_recent, result = "upper"),
+    tpr_before = test_num_before / test_denom_before,
+    tpr_lower_before = prop_ci(test_num_before, test_denom_before, result = "lower"),
+    tpr_upper_before = prop_ci(test_num_recent, test_denom_before, result = "upper")
+  )
+
+```
+## Finalising extra dataset for ELR
+
+```{r}
+# merge datasets
+
+elr_extras_final <- full_join(
+  vax_data,
+  testing_data_final,
+  by = c("iso3")
+)
+
+file_name <- stringr::str_glue("elr_extra_data{Sys.Date()}.rds")
+path_export <- here::here("data",
+                          "clean",
+                          file_name)
+dir_export <- dirname(path_export)
+if (!dir.exists(dir_export)) dir.create(dir_export)
+rio::export(final_dat, path_export)
+
+
+## export data to rds file in current folder
+rio::export(final_dat, file_name)
+
+
+```

--- a/report_sources/elr_review.Rmd
+++ b/report_sources/elr_review.Rmd
@@ -122,6 +122,17 @@ dat_voi
 
 ```
 
+## Load Extra ELR data
+
+```{r }
+
+dat_elr_extra <- find_latest("elr_extra", where = here::here("data")) %>%
+  rio::import()
+
+dat_elr_extra
+
+
+```
 
 
 ------------------------------------

--- a/report_sources/elr_review.Rmd
+++ b/report_sources/elr_review.Rmd
@@ -606,8 +606,9 @@ out_final <- out_full %>%
     # growth_rate_tpr = r_tpr
   )
 
+# join to vaccine coverage/tpr data
 out_final <- out_final %>% 
-     left_join(elr_extras_final, by = "iso3")
+     left_join(dat_elr_extra, by = "iso3")
 
 ```
 

--- a/report_sources/elr_review.Rmd
+++ b/report_sources/elr_review.Rmd
@@ -597,12 +597,17 @@ out_final <- out_full %>%
     growth_rate = r,
     relative_incidence = perc_peak,
     net_increases = net_increases,
-    last_week_tpr = tpr,
-    tpr_change = change_tpr,
+    # remove old tpr for now
+    # last_week_tpr = tpr,
+    # tpr_change = change_tpr,
     epi_classification = classif,
     growth_rate_lower = r_lower,
-    growth_rate_upper = r_upper,
-    growth_rate_tpr = r_tpr)
+    growth_rate_upper = r_upper
+    # growth_rate_tpr = r_tpr
+    )
+
+out_final <- out_final %>% 
+     left_join(elr_extras_final, by = "iso3")
 
 ```
 

--- a/report_sources/elr_review.Rmd
+++ b/report_sources/elr_review.Rmd
@@ -604,7 +604,7 @@ out_final <- out_full %>%
     growth_rate_lower = r_lower,
     growth_rate_upper = r_upper
     # growth_rate_tpr = r_tpr
-    )
+  )
 
 out_final <- out_final %>% 
      left_join(elr_extras_final, by = "iso3")

--- a/scripts/stats.R
+++ b/scripts/stats.R
@@ -23,6 +23,10 @@ prop_ci <- function(k, n,
                     perc = FALSE,
                     conf = 0.95,
                     dec = 2) {
+  if (is.na(n)) {
+    return(NA_integer_)
+  }
+  
   if(n == 0){
     out = c(0,1)
   } else{


### PR DESCRIPTION
Created a pull request to add TPR and Vaccination coverage data to the ELR spreadsheet. 

Process is as follows:

1. Data to be appended are saved in separate .rds to `final_data.rds` in `assemble_data.Rmd`
2. Data are loaded in `elr_review.Rmd`, and merged with final data, before saving in the final spreadsheet