### PR TITLE
flip join to not remove countries like Burundi that have growth rate …

### DIFF
--- a/report_sources/elr_synthesis.Rmd
+++ b/report_sources/elr_synthesis.Rmd
@@ -239,7 +239,7 @@ x <- x %>%
 
 ## add TPR info
 x <- x %>%
-  right_join(select(all_elr_extras, -who_region), by = "iso3")
+  left_join(select(all_elr_extras, -who_region), by = "iso3")
 
 ## add classification to x_all
 x_all <- x_all %>%


### PR DESCRIPTION
…and incidence calculated, but don't have testing data.

Previously, countries for which there was case data and a growth rate calculated were being dropped in this step. So as a result, for some countries like Burundi (currently very serious situation there) the growth rate and % historical incidence were being dropped from the ELR spreadsheet. 

This should fix it.