### PR TITLE
Using CRAN version of reportfactory in actions

### DIFF
--- a/.github/workflows/auto_synthesis.yml
+++ b/.github/workflows/auto_synthesis.yml
@@ -35,9 +35,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek", "emayili", "emayili", "sf")
+          pkgs <- c("remotes", "here", "ISOweek", "emayili", "emayili", "sf", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_afro.yml
+++ b/.github/workflows/auto_update_afro.yml
@@ -38,9 +38,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_all.yml
+++ b/.github/workflows/auto_update_all.yml
@@ -44,9 +44,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_emro.yml
+++ b/.github/workflows/auto_update_emro.yml
@@ -38,9 +38,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_euro.yml
+++ b/.github/workflows/auto_update_euro.yml
@@ -38,9 +38,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_paho.yml
+++ b/.github/workflows/auto_update_paho.yml
@@ -38,9 +38,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_searo.yml
+++ b/.github/workflows/auto_update_searo.yml
@@ -38,9 +38,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/auto_update_wpro.yml
+++ b/.github/workflows/auto_update_wpro.yml
@@ -38,9 +38,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("remotes", "here", "ISOweek")
+          pkgs <- c("remotes", "here", "ISOweek", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
           reportfactory::install_deps(upgrade = "never")
           remotes::install_github("reconhub/trendbreaker", upgrade = "never")

--- a/.github/workflows/refresh_readme.yml
+++ b/.github/workflows/refresh_readme.yml
@@ -36,9 +36,8 @@ jobs:
         run: |
           Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("rmarkdown", "remotes", "here")
+          pkgs <- c("rmarkdown", "remotes", "here", "reportfactory")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("reconhub/reportfactory", upgrade = "never")
           remotes::install_github("reconhub/rfextras", upgrade = "never")
         shell: Rscript {0}
  


### PR DESCRIPTION
This implements the change I suggested in https://github.com/whocov/trend_analysis_public/issues/35. It should fix the currently failing github actions.